### PR TITLE
Add alias k for kubectl with auto-completion

### DIFF
--- a/patches/kubectl-completion.diff
+++ b/patches/kubectl-completion.diff
@@ -1,0 +1,12 @@
+diff -p1 1/kubectl 2/kubectl
+*** 1/kubectl	Wed Jul  3 10:49:41 2024
+--- 2/kubectl	Wed Jul  3 10:50:03 2024
+*************** if [[ $(type -t compopt) = "builtin" ]];
+*** 347,350 ****
+--- 347,352 ----
+      complete -o default -F __start_kubectl kubectl
++     complete -o default -F __start_kubectl k
+  else
+      complete -o default -o nospace -F __start_kubectl kubectl
++     complete -o default -o nospace -F __start_kubectl k
+  fi


### PR DESCRIPTION
To simply the usage of `kubectl` we add `k` as an alias and make it available on the bash auto-completion. See [kubectl-autocomplete](https://kubernetes.io/docs/reference/kubectl/quick-reference/#kubectl-autocomplete).

**Also changed**
* use AS instead of as to avoid `=> WARN: FromAsCasing: 'as' and 'FROM' keywords' casing do not match (line 1)` on workbench startup
* remove unneeded `FROM base`

**What to test**
* `k` can be used within workbench with auto-completion (already tested on Linux)