### PR TITLE
Add docker image test

### DIFF
--- a/.github/workflows/test-container-image.yaml
+++ b/.github/workflows/test-container-image.yaml
@@ -32,6 +32,7 @@ jobs:
       with:
         context: .
         push: false
+        load: true
         tags: ${{ env.IMAGE_NAME }}:test
         file: ./workbench.dockerfile
 

--- a/.github/workflows/test-container-image.yaml
+++ b/.github/workflows/test-container-image.yaml
@@ -34,3 +34,7 @@ jobs:
         push: false
         tags: ${{ env.IMAGE_NAME }}:test
         file: ./workbench.dockerfile
+
+     - name: Simple docker run test
+        run: |
+          docker run --rm ${{ env.IMAGE_NAME }}:test

--- a/.github/workflows/test-container-image.yaml
+++ b/.github/workflows/test-container-image.yaml
@@ -35,6 +35,6 @@ jobs:
         tags: ${{ env.IMAGE_NAME }}:test
         file: ./workbench.dockerfile
 
-     - name: Simple docker run test
-        run: |
-          docker run --rm ${{ env.IMAGE_NAME }}:test
+    - name: Simple docker run test
+      run: |
+        docker run --rm ${{ env.IMAGE_NAME }}:test

--- a/.github/workflows/test-container-image.yaml
+++ b/.github/workflows/test-container-image.yaml
@@ -1,0 +1,36 @@
+name: Test k8s-escape-room workbench container image
+
+on:
+  push:
+    branches:
+    - "**"
+    tags:
+    - "v*.*.*"
+  pull_request:
+    branches:
+    - "main"
+
+env:
+  IMAGE_NAME: k8s-escape-room-workbench
+
+jobs:
+  build-image:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4
+
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v3
+
+    - name: Build container image for tests
+      uses: docker/build-push-action@v6
+      with:
+        context: .
+        push: false
+        tags: ${{ env.IMAGE_NAME }}:test
+        file: ./workbench.dockerfile


### PR DESCRIPTION
To enable Renovate to auto merge patch and minor releases we need at least one passing test.
See: https://docs.renovatebot.com/key-concepts/automerge/#absence-of-tests

As as start, this PR adds a simple workbench tests which builds the workbench and tries to run it without any further checks.