### PR TITLE
Add documentation on how to work with the k8s-esape-room

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,16 @@ Hovering there with your cursor gives you a hint for what you might be looking f
 
 [Local](.docs/local.md)
 
+## Get started
+Regardless of execution environment, there are certain tools you can use to interact with the escape room.
+Once you are in the workbench and have initialized the cluster with `. init.sh`, you can use [k9s](https://k9scli.io/) to see cluster resources in the terminal.
+You can also use [kubectl](https://kubernetes.io/docs/reference/kubectl/).
+
+The following steps need to be done before changes will reflect in the cluster / browser:
+1. Changes to the code need to be saved
+1. The changed resource yaml files need to be applied to the cluster
+1. The browser tab needs to be reloaded, often times a hard reload is neccessary
+
 ### Note
 Tooltip hints are available when hovering with the cursor over the red circles. Note that in the firefox browser the tooltip hints only appear when the browser window is focused.
 Please use another browser or keep in mind to focus the browser window for tooltips when using firefox.

--- a/README.md
+++ b/README.md
@@ -23,11 +23,6 @@ Regardless of execution environment, there are certain tools you can use to inte
 Once you are in the workbench and have initialized the cluster with `. init.sh`, you can use [k9s](https://k9scli.io/) to see cluster resources in the terminal.
 You can also use [kubectl](https://kubernetes.io/docs/reference/kubectl/).
 
-The following steps need to be done before changes will reflect in the cluster / browser:
-1. Changes to the code need to be saved
-1. The changed resource yaml files need to be applied to the cluster
-1. The browser tab needs to be reloaded, often times a hard reload is neccessary
-
 ### Note
 Tooltip hints are available when hovering with the cursor over the red circles. Note that in the firefox browser the tooltip hints only appear when the browser window is focused.
 Please use another browser or keep in mind to focus the browser window for tooltips when using firefox.


### PR DESCRIPTION
This pull request adds simple instructions about first steps when playing the escape room. It mentions, that kubectl and k9s can be used and links to their documentation. Instructions about how to get code changes to reflect in the cluster and browser window are also added. This is the minimum we should provide in my opinion.
Please let me know ideas about additional tips.