### PR TITLE
Remove explicit listing for files in kustomize

### DIFF
--- a/init.d/02.setup-resources/install.sh
+++ b/init.d/02.setup-resources/install.sh
@@ -5,4 +5,9 @@ set -e
 DIR="$(cd "$(dirname "$0")" >/dev/null 2>&1; pwd -P)"
 
 echo "Apply all manifests ..."
+for file in $(ls ${DIR}/manifests/*.yaml | grep -v 'kustomization.yaml'); do
+  kubectl apply -f $file
+done
+
+echo "Apply kustomize manifests ..."
 kustomize build ${DIR}/manifests | kubectl apply -f -

--- a/init.d/02.setup-resources/install.sh
+++ b/init.d/02.setup-resources/install.sh
@@ -4,10 +4,8 @@ set -e
 
 DIR="$(cd "$(dirname "$0")" >/dev/null 2>&1; pwd -P)"
 
-echo "Apply all manifests ..."
-for file in $(ls ${DIR}/manifests/*.yaml | grep -v 'kustomization.yaml'); do
-  kubectl apply -f $file
-done
+echo "Apply all manifests except kustomization ..."
+find "$DIR/manifests/" -name '*.yaml' ! -name 'kustomization.yaml' -exec kubectl apply -f {} \;
 
 echo "Apply kustomize manifests ..."
 kustomize build ${DIR}/manifests | kubectl apply -f -

--- a/init.d/02.setup-resources/manifests/kustomization.yaml
+++ b/init.d/02.setup-resources/manifests/kustomization.yaml
@@ -1,32 +1,6 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
-resources:
-- addons-configmap.yaml
-- addons-deployment.yaml
-- addons-service.yaml
-- cat-configmap.yaml
-- cat-deployment.yaml
-- cat-service.yaml
-- cat-counter-configmap.yaml
-- cat-counter-deployment.yaml
-- cat-counter-service.yaml
-- cat-clusterrole.yaml
-- cat-clusterrolebinding.yaml
-- frontend-deployment.yaml
-- frontend-ingress.yaml
-- frontend-service.yaml
-- orb-configmap.yaml
-- orb-deployment.yaml
-- orb-service.yaml
-- photoframe-configmap.yaml
-- photoframe-deployment.yaml
-- photoframe-service.yaml
-- tome-configmap.yaml
-- tome-deployment.yaml
-- tome-secret.yaml
-- tome-service.yaml
-
 configMapGenerator:
   - name: frontend-pages
     files:


### PR DESCRIPTION
This pull request is a proposal on how to avoid needing to add all new files to the resources section in `kustomization.yaml`.
Wildcards are not allowed in kustomize as also mentioned in the issue https://github.com/steadforce/k8s-escape-room/issues/117.
Instead of applying all definitions via kustomize, only the neccessary file is applied via kustomize and all others are applied as usual via kubectl.
This has some downsides and upsides, please let me know what you think.