### PR TITLE
Fix workbench not working in some cases

### DIFF
--- a/workbench
+++ b/workbench
@@ -53,5 +53,6 @@ docker run --rm \
     --pid host \
     --name escape_room_workbench-$CURRENT_TIME \
     -v $HOME:$HOME$VOLUME_OPTIONS \
+    -v $DIR:$DIR$VOLUME_OPTIONS \
     -it $CONTAINER_HASH \
      $SUDO sh -c "cd $DIR; HOME=$HOME $K8S_CONFIG $CMD"


### PR DESCRIPTION
Fixes problems when the workbench is run from a folder that's not in the user's home directory.

This change might also be required for the Windows-scripts (it was already fixed in the Codespaces-script).