### PR TITLE
Fix GitHub workflow syntax and move frontend check to own workflow

### DIFF
--- a/.github/workflows/test-container-image.yaml
+++ b/.github/workflows/test-container-image.yaml
@@ -39,8 +39,3 @@ jobs:
     - name: Simple docker run test
       run: |
         docker run --rm ${{ env.IMAGE_NAME }}:test
-
-  frontend-test:
-    - name: Test frontend
-      run: |
-        yarn --cwd init.d/02.frontend/escape-room-frontend ci

--- a/.github/workflows/test-frontend.yaml
+++ b/.github/workflows/test-frontend.yaml
@@ -3,12 +3,12 @@ name: Test escape room frontend
 on:
   push:
     branches:
-    - "**"
+      - "**"
     tags:
-    - "v*.*.*"
+      - "v*.*.*"
   pull_request:
     branches:
-    - "main"
+      - "main"
 
 jobs:
   frontend-test:
@@ -21,13 +21,13 @@ jobs:
         working-directory: ./init.d/02.frontend/escape-room-frontend
 
     steps:
-    - name: Checkout repository
-      uses: actions/checkout@v4
+      - name: Checkout repository
+        uses: actions/checkout@v4
 
-    - name: Test frontend
-      run: |
-        yarn ci
+      - name: Test frontend
+        run: |
+          yarn && yarn ci
 
-    - name: Test frontend docker build
-      run: |
-        docker build -t test .
+      - name: Test frontend docker build
+        run: |
+          docker build -t test .

--- a/.github/workflows/test-frontend.yaml
+++ b/.github/workflows/test-frontend.yaml
@@ -16,11 +16,18 @@ jobs:
     permissions:
       contents: read
       packages: write
+    defaults:
+      run:
+        working-directory: ./init.d/02.frontend/escape-room-frontend
 
     steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4
+
     - name: Test frontend
       run: |
-        yarn --cwd init.d/02.frontend/escape-room-frontend ci
+        yarn ci
+
     - name: Test frontend docker build
       run: |
-        docker build -t test "$PWD/init.d/02.frontend/escape-room-frontend"
+        docker build -t test .

--- a/.github/workflows/test-frontend.yaml
+++ b/.github/workflows/test-frontend.yaml
@@ -1,0 +1,26 @@
+name: Test escape room frontend
+
+on:
+  push:
+    branches:
+    - "**"
+    tags:
+    - "v*.*.*"
+  pull_request:
+    branches:
+    - "main"
+
+jobs:
+  frontend-test:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+    - name: Test frontend
+      run: |
+        yarn --cwd init.d/02.frontend/escape-room-frontend ci
+    - name: Test frontend docker build
+      run: |
+        docker build -t test "$PWD/init.d/02.frontend/escape-room-frontend"


### PR DESCRIPTION
I broke the GitHub CI when I added a test for the frontend code (syntax error in the Action).

This PR fixes that issue and adds a new, dedicated workflow for the frontend tests