### PR TITLE
Fix frontend not updating on running `. init.sh`

### DIFF
--- a/init.d/00.kind-cluster/cluster.yaml
+++ b/init.d/00.kind-cluster/cluster.yaml
@@ -6,7 +6,7 @@ networking:
   # kubeProxyMode: "ipvs"
 nodes:
   - role: control-plane
-    image: kindest/node:v1.33.1
+    image: kindest/node:v1.32.5
     kubeadmConfigPatches:
     - |
       kind: InitConfiguration

--- a/init.d/02.frontend/escape-room-frontend/src/components/GameStateContext.tsx
+++ b/init.d/02.frontend/escape-room-frontend/src/components/GameStateContext.tsx
@@ -116,7 +116,7 @@ export const GameStateContextProvider: React.FC<{ children: React.ReactNode }> =
 
     const checkState = () => {
         const catPromise = fetch("/cat").then(r => r.ok);
-        const catCounterPromise = fetch("/cat-counter").then(r => r.text()).then(t => t.replace(/"/g, '')).then(n => Number(n)).catch(_ => 0);
+        const catCounterPromise = fetch("/cat-counter").then(r => r.text()).then(t => t.replace(/"/g, '')).then(n => Number(n)).catch(() => 0);
         const orbPromise = fetch("/orb").then(r => r.ok);
         const tomePromise = fetch("/tome").then(r => r.ok);
         const photoFramePromise = fetch("/photoframe/photo0.png").then(r => r.ok);

--- a/init.d/02.frontend/escape-room-frontend/src/components/GameStateContext.tsx
+++ b/init.d/02.frontend/escape-room-frontend/src/components/GameStateContext.tsx
@@ -116,7 +116,7 @@ export const GameStateContextProvider: React.FC<{ children: React.ReactNode }> =
 
     const checkState = () => {
         const catPromise = fetch("/cat").then(r => r.ok);
-        const catCounterPromise = fetch("/cat-counter").then(r => r.text()).then(t => t.replace(/"/g, '')).then(n => Number(n));
+        const catCounterPromise = fetch("/cat-counter").then(r => r.text()).then(t => t.replace(/"/g, '')).then(n => Number(n)).catch(_ => 0);
         const orbPromise = fetch("/orb").then(r => r.ok);
         const tomePromise = fetch("/tome").then(r => r.ok);
         const photoFramePromise = fetch("/photoframe/photo0.png").then(r => r.ok);

--- a/init.d/02.frontend/escape-room-frontend/src/components/GameStateContext.tsx
+++ b/init.d/02.frontend/escape-room-frontend/src/components/GameStateContext.tsx
@@ -116,7 +116,7 @@ export const GameStateContextProvider: React.FC<{ children: React.ReactNode }> =
 
     const checkState = () => {
         const catPromise = fetch("/cat").then(r => r.ok);
-        const catCounterPromise = fetch("/cat-counter").then(r => r.text()).then(t => t.replace(/"/g, '')).then(n => Number(n)).catch(() => 0);
+        const catCounterPromise = fetch("/cat-counter").then(r => r.text()).then(t => t.replace(/"/g, '')).then(n => Number(n)).catch(e => {console.error(e); return 0;});
         const orbPromise = fetch("/orb").then(r => r.ok);
         const tomePromise = fetch("/tome").then(r => r.ok);
         const photoFramePromise = fetch("/photoframe/photo0.png").then(r => r.ok);


### PR DESCRIPTION
This pull request adds a catch for the cat counter inside the frontend. An unhandled error previously led to the riddle status checks being skipped. Now riddles status should be up to date in one second, also after running `. init.sh`.
The error could be solved by downgrading the kind version.