### PR TITLE
Permanent leaderboard

### DIFF
--- a/init.d/02.frontend/escape-room-frontend/src/components/HighscorePreview.css
+++ b/init.d/02.frontend/escape-room-frontend/src/components/HighscorePreview.css
@@ -1,6 +1,6 @@
 h4 {
   padding: 0;
-  margin: 0;
+  margin: 0 5px;
 }
 
 .highscorePreview {

--- a/init.d/02.frontend/escape-room-frontend/src/components/HighscorePreview.css
+++ b/init.d/02.frontend/escape-room-frontend/src/components/HighscorePreview.css
@@ -1,0 +1,32 @@
+h4 {
+  padding: 0;
+  margin: 0;
+}
+
+.highscorePreview {
+  width: 15rem;
+  position: absolute;
+  left: 0;
+  bottom: 150px;
+  font-size: 15px;
+  text-align: left;
+  border-collapse: collapse;
+}
+
+.highscorePreview th {
+  color: white;
+  border: 1px solid white;
+  padding: 5px;
+  background-color: rgba(255, 255, 255, 0.2);
+}
+
+.highscorePreview td {
+  padding: 5px;
+  color: white;
+  border: 1px solid white;
+  background-color: rgba(255, 255, 255, 0.1);
+}
+
+.highscorePreview tr:hover {
+  background-color: rgba(255, 255, 255, 0.4);
+}

--- a/init.d/02.frontend/escape-room-frontend/src/components/HighscorePreview.tsx
+++ b/init.d/02.frontend/escape-room-frontend/src/components/HighscorePreview.tsx
@@ -1,21 +1,21 @@
 import { useGameStateContext } from "./GameStateContext";
-import "./HighscoreTable.css";
+import "./HighscorePreview.css";
 
-function HighscoreTable() {
+function HighscorePreview() {
     const gameState = useGameStateContext();
 
     return (
-        <div className="highscore">
-            <h2>Highscores</h2>
-            <table className="highscoreTable" id="highscoreTable">
+        <div className="highscorePreview">
+            <h4>Highscores</h4>
+            <table className="highscore" id="highscore">
                 <thead>
                     <tr>
                         <th>Wizard</th>
                         <th>Time needed</th>
                     </tr>
                 </thead>
-                <tbody id="highscoreTableBody">
-                    {[...gameState.scores()].slice(0, 5).sort((a, b) => a.score.localeCompare(b.score)).map((score, index) => (
+                <tbody id="highscorePreviewBody">
+                    {[...gameState.scores()].slice(0, 3).sort((a, b) => a.score.localeCompare(b.score)).map((score, index) => (
                         <tr key={index}>
                             <td>
                                 {score.name}
@@ -31,4 +31,4 @@ function HighscoreTable() {
     )
 }
 
-export default HighscoreTable
+export default HighscorePreview

--- a/init.d/02.frontend/escape-room-frontend/src/components/HighscoreTable.css
+++ b/init.d/02.frontend/escape-room-frontend/src/components/HighscoreTable.css
@@ -1,0 +1,24 @@
+.highscoreTable {
+  width: 25rem;
+  margin: 20px 60px;
+  font-size: 25px;
+  text-align: left;
+  border-collapse: collapse;
+}
+
+.highscoreTable th {
+  color: white;
+  border: 1px solid white;
+  padding: 10px;
+  background-color: rgba(255, 255, 255, 0.1);
+}
+
+.highscoreTable td {
+  padding: 10px;
+  color: white;
+  border: 1px solid white;
+}
+
+.highscoreTable tr:hover {
+  background-color: rgba(255, 255, 255, 0.2);
+}

--- a/init.d/02.frontend/escape-room-frontend/src/components/HighscoreTable.tsx
+++ b/init.d/02.frontend/escape-room-frontend/src/components/HighscoreTable.tsx
@@ -4,7 +4,7 @@ function HighscoreTable() {
     const gameState = useGameStateContext();
 
     return (
-        <>
+        <div className="highscore">
             <h2>Highscores</h2>
             <table className="highscoreTable" id="highscoreTable">
                 <thead>
@@ -26,7 +26,7 @@ function HighscoreTable() {
                     ))}
                 </tbody>
             </table>
-        </>
+        </div>
     )
 }
 

--- a/init.d/02.frontend/escape-room-frontend/src/components/HighscoreTable.tsx
+++ b/init.d/02.frontend/escape-room-frontend/src/components/HighscoreTable.tsx
@@ -1,0 +1,33 @@
+import { useGameStateContext } from "./GameStateContext";
+
+function HighscoreTable() {
+    const gameState = useGameStateContext();
+
+    return (
+        <>
+            <h2>Highscores</h2>
+            <table className="highscoreTable" id="highscoreTable">
+                <thead>
+                    <tr>
+                        <th>Wizard</th>
+                        <th>Time needed</th>
+                    </tr>
+                </thead>
+                <tbody id="highscoreTableBody">
+                    {[...gameState.scores()].sort((a, b) => a.score.localeCompare(b.score)).map((score, index) => (
+                        <tr key={index}>
+                            <td>
+                                {score.name}
+                            </td>
+                            <td>
+                                {score.score}
+                            </td>
+                        </tr>
+                    ))}
+                </tbody>
+            </table>
+        </>
+    )
+}
+
+export default HighscoreTable

--- a/init.d/02.frontend/escape-room-frontend/src/views/App.css
+++ b/init.d/02.frontend/escape-room-frontend/src/views/App.css
@@ -90,7 +90,6 @@ h2 {
 
 .highscoreTable {
   width: 25rem;
-  margin: 20px 60px;
   font-size: 25px;
   text-align: left;
   border-collapse: collapse;

--- a/init.d/02.frontend/escape-room-frontend/src/views/App.css
+++ b/init.d/02.frontend/escape-room-frontend/src/views/App.css
@@ -88,30 +88,6 @@ h2 {
   display: inline-block;
 }
 
-.highscoreTable {
-  width: 25rem;
-  font-size: 25px;
-  text-align: left;
-  border-collapse: collapse;
-}
-
-.highscoreTable th {
-  color: white;
-  border: 1px solid white;
-  padding: 10px;
-  background-color: rgba(255, 255, 255, 0.1);
-}
-
-.highscoreTable td {
-  padding: 10px;
-  color: white;
-  border: 1px solid white;
-}
-
-.highscoreTable tr:hover {
-  background-color: rgba(255, 255, 255, 0.2);
-}
-
 .room {
   width: 100vw;
   height: 100vh;

--- a/init.d/02.frontend/escape-room-frontend/src/views/Endscreen.tsx
+++ b/init.d/02.frontend/escape-room-frontend/src/views/Endscreen.tsx
@@ -2,6 +2,7 @@ import './Endscreen.css'
 import banner from '../assets/banner.png'
 import { Link } from 'react-router-dom'
 import { useGameStateContext } from '../components/GameStateContext'
+import HighscoreTable from '../components/HighscoreTable';
 
 function Endscreen() {
     const gameState = useGameStateContext();
@@ -23,27 +24,7 @@ function Endscreen() {
                 </h1>
                 <h2>You finished the Kubernetes Escape Room Game</h2>
                 <p className="comment">You took <em id="timeTaken">{timeTaken()}</em>. Great job!</p>
-                <h2>Highscores</h2>
-                <table className="highscoreTable" id="highscoreTable">
-                    <thead>
-                        <tr>
-                            <th>Wizard</th>
-                            <th>Time needed</th>
-                        </tr>
-                    </thead>
-                    <tbody id="highscoreTableBody">
-                        {[...gameState.scores()].sort((a, b) => a.score.localeCompare(b.score)).map((score, index) => (
-                            <tr key={index}>
-                                <td>
-                                    {score.name}
-                                </td>
-                                <td>
-                                    {score.score}
-                                </td>
-                            </tr>
-                        ))}
-                    </tbody>
-                </table>
+                <HighscoreTable />
                 <p className="comment" id="resetInstruction">Reset the game by running the <em>. init.sh</em> script before starting a new game.</p>
                 <br />
                 <Link className="screenbutton" to="/" onClick={gameState.restart}>

--- a/init.d/02.frontend/escape-room-frontend/src/views/Room.css
+++ b/init.d/02.frontend/escape-room-frontend/src/views/Room.css
@@ -1,5 +1,0 @@
-.highscore {
-    position: absolute;
-    bottom: 0;
-    left: 30%;
-}

--- a/init.d/02.frontend/escape-room-frontend/src/views/Room.css
+++ b/init.d/02.frontend/escape-room-frontend/src/views/Room.css
@@ -1,0 +1,5 @@
+.highscoreTable {
+    position: absolute;
+    top: 50%;
+    left: 0;
+}

--- a/init.d/02.frontend/escape-room-frontend/src/views/Room.css
+++ b/init.d/02.frontend/escape-room-frontend/src/views/Room.css
@@ -1,5 +1,5 @@
-.highscoreTable {
+.highscore {
     position: absolute;
-    top: 50%;
-    left: 0;
+    bottom: 0;
+    left: 30%;
 }

--- a/init.d/02.frontend/escape-room-frontend/src/views/Room.tsx
+++ b/init.d/02.frontend/escape-room-frontend/src/views/Room.tsx
@@ -5,8 +5,7 @@ import PhotoFrameRiddle from '../components/PhotoFrameRiddle'
 import TomeRiddle from '../components/TomeRiddle'
 import banner from '../assets/banner.png'
 import GiveUp from '../components/GiveUp'
-import HighscoreTable from '../components/HighscoreTable'
-import './Room.css'
+import HighscorePreview from '../components/HighscorePreview'
 
 function Room() {
 
@@ -21,7 +20,7 @@ function Room() {
                 <TomeRiddle />
                 <div id="addons" className="addons"></div>
             </div>
-            <HighscoreTable />
+            <HighscorePreview />
             <GiveUp />
             <GameStatus />
         </>

--- a/init.d/02.frontend/escape-room-frontend/src/views/Room.tsx
+++ b/init.d/02.frontend/escape-room-frontend/src/views/Room.tsx
@@ -6,6 +6,7 @@ import TomeRiddle from '../components/TomeRiddle'
 import banner from '../assets/banner.png'
 import GiveUp from '../components/GiveUp'
 import HighscoreTable from '../components/HighscoreTable'
+import './Room.css'
 
 function Room() {
 

--- a/init.d/02.frontend/escape-room-frontend/src/views/Room.tsx
+++ b/init.d/02.frontend/escape-room-frontend/src/views/Room.tsx
@@ -5,6 +5,7 @@ import PhotoFrameRiddle from '../components/PhotoFrameRiddle'
 import TomeRiddle from '../components/TomeRiddle'
 import banner from '../assets/banner.png'
 import GiveUp from '../components/GiveUp'
+import HighscoreTable from '../components/HighscoreTable'
 
 function Room() {
 
@@ -19,6 +20,7 @@ function Room() {
                 <TomeRiddle />
                 <div id="addons" className="addons"></div>
             </div>
+            <HighscoreTable />
             <GiveUp />
             <GameStatus />
         </>

--- a/init.d/04.setup-resources/manifests/frontend/style.css
+++ b/init.d/04.setup-resources/manifests/frontend/style.css
@@ -112,31 +112,6 @@ h2 {
     border-top-right-radius: 1rem;
 }
 
-.highscoreTable {
-    width: 25rem;
-    margin: 20px 60px;
-    font-size: 25px;
-    text-align: left;
-    border-collapse: collapse;
-}
-
-.highscoreTable th {
-    color: white;
-    border: 1px solid white;
-    padding: 10px;
-    background-color: rgba(255, 255, 255, 0.1);
-}
-
-.highscoreTable td {
-    padding: 10px;
-    color: white;
-    border: 1px solid white;
-}
-
-.highscoreTable tr:hover {
-    background-color: rgba(255, 255, 255, 0.2);
-}
-
 .progress {
     position: fixed;
     left: 0;


### PR DESCRIPTION
This pull request addresses issue #185 . A permanent smaller version of the leaderboard was added to the left of the room. It is not possible to use the lower right, as this is reserved for navigation to addon rooms. Lower center is currently taken by the give up button. Lower left is taken by clock and riddle status. Upper left and center are taken by the headline and upper right is taken by the Steadforce logo.
This is what the escape room looks like with the newly added permanent leaderboard.
<img width="3839" height="2004" alt="Screenshot from 2025-07-17 12-26-44" src="https://github.com/user-attachments/assets/a0196684-2c3d-4cab-aa68-57a3fe28cb22" />
Please let me know any feedback.