### PR TITLE
Add mtu and portforward hints and update picture

### DIFF
--- a/.docs/codespaces.md
+++ b/.docs/codespaces.md
@@ -17,6 +17,18 @@ kind network
 docker network create --driver=bridge --subnet=10.172.242.0/24 --ip-range=10.172.242.0/28 --gateway=10.172.242.1 kind
 ```
 
+**Hint**
+
+If TLS timeout happens e.g. on image pulls there might be a mtu mismatch between the kind network and e.g. a VPN
+client (like `Tailscale`). In this case the mtu can be specified as option on the network creation.
+Note that the network (and containers which use this network) needs to be recreated if already present.
+
+This configures the `kind` networks with an mtu of `1280`:
+
+```shell
+docker network create --driver=bridge --subnet=10.172.242.0/24 --ip-range=10.172.242.0/28 --gateway=10.172.242.1 -o "com.docker.network.driver.mtu"="1280" kind
+```
+
 ## Setup
 
 ```bash

--- a/.docs/local.md
+++ b/.docs/local.md
@@ -22,6 +22,18 @@ kind network
 docker network create --driver=bridge --subnet=10.172.242.0/24 --ip-range=10.172.242.0/28 --gateway=10.172.242.1 kind
 ```
 
+**Hint**
+
+If TLS timeout happens e.g. on image pulls there might be a mtu mismatch between the kind network and e.g. a VPN
+client (like `Tailscale`). In this case the mtu can be specified as option on the network creation.
+Note that the network (and containers which use this network) needs to be recreated if already present.
+
+This configures the `kind` networks with an mtu of `1280`:
+
+```shell
+docker network create --driver=bridge --subnet=10.172.242.0/24 --ip-range=10.172.242.0/28 --gateway=10.172.242.1 -o "com.docker.network.driver.mtu"="1280" kind
+```
+
 ## Setup
 
 ```bash
@@ -44,3 +56,20 @@ To access the escape room UI in your browser please use [http://localhost/](http
 ## Available tools
 * K9s
 * kubectl
+
+## Port forwarding
+
+Port forwards can be done in the following way (within the workplace container):
+
+```shell
+# Get IP of the workplace in the kind network
+> hostname -I
+10.172.242.6
+# Forward e.g. port 80 of frontend-service Service to local port 8081 on the kind network host:
+kubectl port-forward services/frontend-service --address 0.0.0.0 8081:80
+```
+
+The endpoint can then be reached via `<workplace-ip>:8081`.
+
+**Hint**
+Port forwards can also be opened easily via `k9s` in a similar way.


### PR DESCRIPTION
This PR adds some mtu related hints to both readmes (not ideal that we have two with identical information but I would keep this for now).

Also added hints for port forwarding (if needed) to the local readme.
Not sure how those port forwards could be used in Github codespaces. I wasn't successful on a short test with `kubectl` and the port options in Visual Studio Code within the codespace.
Thus I've just added it to the local readme.

If we think it is worth we could also create an issue for port forwarding in Github codespaces to investigate this further.

I also updated the picture with the unresolved screen.