### PR TITLE
Fix cats not appearing

### DIFF
--- a/init.d/04.setup-resources/manifests/cat-counter-deployment.yaml
+++ b/init.d/04.setup-resources/manifests/cat-counter-deployment.yaml
@@ -16,13 +16,16 @@ spec:
       automountServiceAccountToken: true
       containers:
       - name: cat-counter
-        image: python:3-alpine
+        image: python:3.13-alpine
         command:
           - /bin/sh
           - -c
           - |
-            pip install kubernetes
-            pip install fastapi[standard]
+            set -e
+            [ -z "$KUBERNETES_SERVICE_HOST" ] && { echo "Error: KUBERNETES_SERVICE_HOST is not set."; exit 1; }
+            pip install --upgrade pip
+            pip install --only-binary=:all: kubernetes
+            pip install --only-binary=:all: fastapi[standard]
             fastapi run /scripts/main.py --port 80
         ports:
         - containerPort: 8000


### PR DESCRIPTION
There is a know race condition when creating new pods, leading to missing `KUBERNETES_SERVICE_HOST` and `KUBERNETES_SERVICE_PORT` in rare cases. The issues on github were closed, but the problem still seems to come up. See:
- https://github.com/kubernetes/kubernetes/issues/40973
- https://github.com/kubernetes/kubernetes/issues/96070

A workaround for the mentioned race condition was added. Before installing and starting fastapi a check for `KUBERNETES_SERVICE_HOST` is added, so the pod is restarted if needed.

Also instructions to install `kubernetes` and `fastapi` from binary only were added. Otherwise pip would try to build them from source leading to an `OOMKill`.

Please let me know if you can see the cats both from a fresh cluster bootstrap and after running `. init.sh` again.