### PR TITLE
Install yarn if not cached

### DIFF
--- a/.github/workflows/test-frontend.yaml
+++ b/.github/workflows/test-frontend.yaml
@@ -24,6 +24,9 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v6
 
+      - name: Enable Corepack
+        run: corepack enable
+
       - name: Setup Node.js
         uses: actions/setup-node@v6
         with:


### PR DESCRIPTION
This pull request ensures yarn is installed if it is not cached in local act execution.

To test remove all yarn related cache and execute using act.
Without this change there is an error `Unable to locate executable file: yarn`.
With this change the test passes.